### PR TITLE
feat: add budget models and IPC APIs

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -67,6 +67,9 @@ npx knex migrate:latest
 - `src/main/models/Client.ts` - Model do Cliente
 - `src/main/services/ClientService.ts` - Serviços de negócio
 - `src/main/handlers/clientHandlers.ts` - Handlers IPC para comunicação com o frontend
+- `src/main/models/Budget.ts` - Model de Orçamento
+- `src/main/services/BudgetService.ts` - Serviços de orçamento
+- `src/main/handlers/budgetHandlers.ts` - Handlers IPC para orçamentos
 
 ### API Disponível
 
@@ -78,6 +81,11 @@ O backend expõe as seguintes operações via IPC:
 - `clients:update` - Atualizar cliente
 - `clients:delete` - Deletar cliente
 - `clients:search` - Buscar clientes por termo
+- `budgets:getAll` - Buscar todos os orçamentos
+- `budgets:getById` - Buscar orçamento por ID
+- `budgets:create` - Criar novo orçamento
+- `budgets:update` - Atualizar orçamento
+- `budgets:delete` - Deletar orçamento
 
 ### Uso no Frontend
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,43 @@ model Client {
   @@map("clients")
 }
 
+model Budget {
+  id          Int          @id @default(autoincrement())
+  rev         Int          @default(0)
+  numero      String       @unique @db.VarChar(255)
+  cliente     String       @db.VarChar(255)
+  projeto     String       @db.VarChar(255)
+  valor       Decimal      @db.Decimal(10, 2)
+  status      String       @db.VarChar(50)
+  emissao     DateTime     @db.Date
+  validade    DateTime     @db.Date
+  resp        String       @db.VarChar(255)
+  margem      Decimal      @db.Decimal(5, 2)
+  slaDias     Int?
+  enviado     Boolean      @default(false)
+  respondeuEm DateTime?    @db.Date
+  created_at  DateTime     @default(now()) @db.Timestamptz(6)
+  updated_at  DateTime     @default(now()) @updatedAt @db.Timestamptz(6)
+
+  items       BudgetItem[]
+
+  @@map("budgets")
+}
+
+model BudgetItem {
+  id        Int     @id @default(autoincrement())
+  budget    Budget  @relation(fields: [budgetId], references: [id], onDelete: Cascade)
+  budgetId  Int
+  categoria String  @db.VarChar(255)
+  codigo    String? @db.VarChar(255)
+  nome      String  @db.VarChar(255)
+  un        String  @db.VarChar(20)
+  qtd       Decimal @db.Decimal(10, 2)
+  preco     Decimal @db.Decimal(10, 2)
+
+  @@map("budget_items")
+}
+
 model knex_migrations {
   id             Int       @id @default(autoincrement())
   name           String?   @db.VarChar(255)

--- a/src/main/handlers/budgetHandlers.ts
+++ b/src/main/handlers/budgetHandlers.ts
@@ -1,0 +1,49 @@
+import { ipcMain } from 'electron'
+import { BudgetService } from '../services/BudgetService'
+import { withLogging } from '../utils/ipcLogger'
+
+// Register IPC handlers for Budget operations
+export function registerBudgetHandlers() {
+  // Get all budgets
+  ipcMain.handle(
+    'budgets:getAll',
+    withLogging('budgets:getAll', async () => {
+      return await BudgetService.getAllBudgets()
+    })
+  )
+
+  // Get budget by ID
+  ipcMain.handle(
+    'budgets:getById',
+    withLogging('budgets:getById', async (_, id: number) => {
+      return await BudgetService.getBudgetById(id)
+    })
+  )
+
+  // Create new budget
+  ipcMain.handle(
+    'budgets:create',
+    withLogging('budgets:create', async (_, data) => {
+      return await BudgetService.createBudget(data)
+    })
+  )
+
+  // Update budget
+  ipcMain.handle(
+    'budgets:update',
+    withLogging('budgets:update', async (_, id: number, data) => {
+      return await BudgetService.updateBudget(id, data)
+    })
+  )
+
+  // Delete budget
+  ipcMain.handle(
+    'budgets:delete',
+    withLogging('budgets:delete', async (_, id: number) => {
+      return await BudgetService.deleteBudget(id)
+    })
+  )
+
+  console.log('✅ Budget IPC handlers registered with logging')
+}
+

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,6 +4,7 @@ import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
 import { initializeDatabase, closeDatabase } from './database'
 import { registerClientHandlers } from './handlers/clientHandlers'
+import { registerBudgetHandlers } from './handlers/budgetHandlers'
 
 function createWindow(): void {
   // Create the browser window.
@@ -55,6 +56,7 @@ app.whenReady().then(async () => {
 
   // Register IPC handlers
   registerClientHandlers()
+  registerBudgetHandlers()
 
   // Default open or close DevTools by F12 in development
   // and ignore CommandOrControl + R in production.

--- a/src/main/models/Budget.ts
+++ b/src/main/models/Budget.ts
@@ -1,0 +1,161 @@
+import { prisma } from '../database'
+import { Budget as PrismaBudget, BudgetItem as PrismaBudgetItem } from '@prisma/client'
+import { Decimal } from '@prisma/client/runtime/library'
+
+// ------------------------------
+// Budget & BudgetItem interfaces
+// ------------------------------
+
+export interface BudgetItem {
+  id: number
+  categoria: string
+  codigo: string | null
+  nome: string
+  un: string
+  qtd: number
+  preco: number
+}
+
+export interface Budget {
+  id: number
+  rev: number
+  numero: string
+  cliente: string
+  projeto: string
+  valor: number
+  status: string
+  emissao: string
+  validade: string
+  resp: string
+  margem: number
+  slaDias: number | null
+  enviado: boolean
+  respondeuEm: string | null
+  created_at: Date
+  updated_at: Date
+  items?: BudgetItem[]
+}
+
+// ------------------------------
+// Serialization helpers
+// ------------------------------
+
+function serializeItem(item: PrismaBudgetItem): BudgetItem {
+  return {
+    ...item,
+    codigo: item.codigo ?? null,
+    qtd: Number(item.qtd),
+    preco: Number(item.preco)
+  }
+}
+
+function serializeBudget(budget: PrismaBudget & { items?: PrismaBudgetItem[] }): Budget {
+  return {
+    id: budget.id,
+    rev: budget.rev,
+    numero: budget.numero,
+    cliente: budget.cliente,
+    projeto: budget.projeto,
+    valor: Number(budget.valor),
+    status: budget.status,
+    emissao: budget.emissao.toISOString().split('T')[0],
+    validade: budget.validade.toISOString().split('T')[0],
+    resp: budget.resp,
+    margem: Number(budget.margem),
+    slaDias: budget.slaDias ?? null,
+    enviado: budget.enviado,
+    respondeuEm: budget.respondeuEm
+      ? budget.respondeuEm.toISOString().split('T')[0]
+      : null,
+    created_at: budget.created_at,
+    updated_at: budget.updated_at,
+    items: budget.items?.map(serializeItem)
+  }
+}
+
+// ------------------------------
+// Model implementation
+// ------------------------------
+
+export class BudgetModel {
+  static async findAll(): Promise<Budget[]> {
+    const budgets = await prisma.budget.findMany({
+      include: { items: true },
+      orderBy: { created_at: 'desc' }
+    })
+    return budgets.map(serializeBudget)
+  }
+
+  static async findById(id: number): Promise<Budget | null> {
+    const budget = await prisma.budget.findUnique({
+      where: { id },
+      include: { items: true }
+    })
+    return budget ? serializeBudget(budget) : null
+  }
+
+  static async create(
+    budget: Omit<Budget, 'id' | 'created_at' | 'updated_at'> & { items?: Omit<BudgetItem, 'id'>[] }
+  ): Promise<Budget> {
+    const items = budget.items?.map((item) => ({
+      categoria: item.categoria,
+      codigo: item.codigo ?? undefined,
+      nome: item.nome,
+      un: item.un,
+      qtd: new Decimal(item.qtd),
+      preco: new Decimal(item.preco)
+    }))
+
+    const data = {
+      ...budget,
+      emissao: new Date(budget.emissao),
+      validade: new Date(budget.validade),
+      respondeuEm: budget.respondeuEm ? new Date(budget.respondeuEm) : null,
+      valor: new Decimal(budget.valor),
+      margem: new Decimal(budget.margem),
+      items: items ? { create: items } : undefined
+    }
+
+    const created = await prisma.budget.create({ data, include: { items: true } })
+    return serializeBudget(created)
+  }
+
+  static async update(
+    id: number,
+    budget: Partial<Omit<Budget, 'id' | 'created_at' | 'updated_at' | 'items'>>
+  ): Promise<Budget | null> {
+    try {
+      const data: any = {
+        ...budget,
+        valor: budget.valor !== undefined ? new Decimal(budget.valor) : undefined,
+        margem: budget.margem !== undefined ? new Decimal(budget.margem) : undefined
+      }
+
+      const updated = await prisma.budget.update({
+        where: { id },
+        data: {
+          ...data,
+          emissao: budget.emissao ? new Date(budget.emissao) : undefined,
+          validade: budget.validade ? new Date(budget.validade) : undefined,
+          respondeuEm: budget.respondeuEm
+            ? new Date(budget.respondeuEm)
+            : undefined
+        },
+        include: { items: true }
+      })
+      return serializeBudget(updated)
+    } catch (error) {
+      return null
+    }
+  }
+
+  static async delete(id: number): Promise<boolean> {
+    try {
+      await prisma.budget.delete({ where: { id } })
+      return true
+    } catch (error) {
+      return false
+    }
+  }
+}
+

--- a/src/main/services/BudgetService.ts
+++ b/src/main/services/BudgetService.ts
@@ -1,0 +1,92 @@
+import { z } from 'zod'
+import { BudgetModel, Budget } from '../models/Budget'
+
+// ------------------------------
+// Validation schemas
+// ------------------------------
+
+const budgetItemSchema = z.object({
+  categoria: z.string(),
+  codigo: z.string().optional(),
+  nome: z.string(),
+  un: z.string(),
+  qtd: z.number(),
+  preco: z.number()
+})
+
+const budgetSchema = z.object({
+  rev: z.number().default(0),
+  numero: z.string(),
+  cliente: z.string(),
+  projeto: z.string(),
+  valor: z.number(),
+  status: z.string(),
+  emissao: z.string(),
+  validade: z.string(),
+  resp: z.string(),
+  margem: z.number(),
+  slaDias: z.number().nullable().optional(),
+  enviado: z.boolean().optional(),
+  respondeuEm: z.string().nullable().optional(),
+  items: z.array(budgetItemSchema).optional()
+})
+
+// ------------------------------
+// Service implementation
+// ------------------------------
+
+export class BudgetService {
+  static async getAllBudgets(): Promise<Budget[]> {
+    try {
+      return await BudgetModel.findAll()
+    } catch (error) {
+      console.error('Error fetching budgets:', error)
+      throw new Error('Failed to fetch budgets')
+    }
+  }
+
+  static async getBudgetById(id: number): Promise<Budget | null> {
+    try {
+      return await BudgetModel.findById(id)
+    } catch (error) {
+      console.error(`Error fetching budget with id ${id}:`, error)
+      throw new Error('Failed to fetch budget')
+    }
+  }
+
+  static async createBudget(data: unknown): Promise<Budget> {
+    try {
+      const validated = budgetSchema.parse(data)
+      return await BudgetModel.create(validated)
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`Dados inválidos: ${error.issues.map((e) => e.message).join(', ')}`)
+      }
+      console.error('Error creating budget:', error)
+      throw error
+    }
+  }
+
+  static async updateBudget(id: number, data: unknown): Promise<Budget | null> {
+    try {
+      const validated = budgetSchema.partial().parse(data)
+      return await BudgetModel.update(id, validated)
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        throw new Error(`Dados inválidos: ${error.issues.map((e) => e.message).join(', ')}`)
+      }
+      console.error(`Error updating budget with id ${id}:`, error)
+      throw error
+    }
+  }
+
+  static async deleteBudget(id: number): Promise<boolean> {
+    try {
+      return await BudgetModel.delete(id)
+    } catch (error) {
+      console.error(`Error deleting budget with id ${id}:`, error)
+      throw error
+    }
+  }
+}
+

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,4 +1,5 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
+import type { Budget } from '../renderer/src/shared/types'
 
 declare global {
   interface Window {
@@ -11,6 +12,13 @@ declare global {
         update: (id: number, clientData: any) => Promise<any | null>
         delete: (id: number) => Promise<boolean>
         search: (searchTerm: string) => Promise<any[]>
+      }
+      budgets: {
+        getAll: () => Promise<Budget[]>
+        getById: (id: number) => Promise<Budget | null>
+        create: (budgetData: any) => Promise<Budget>
+        update: (id: number, budgetData: any) => Promise<Budget | null>
+        delete: (id: number) => Promise<boolean>
       }
     }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,13 @@ const api = {
     update: (id: number, clientData: any) => ipcRenderer.invoke('clients:update', id, clientData),
     delete: (id: number) => ipcRenderer.invoke('clients:delete', id),
     search: (searchTerm: string) => ipcRenderer.invoke('clients:search', searchTerm)
+  },
+  budgets: {
+    getAll: () => ipcRenderer.invoke('budgets:getAll'),
+    getById: (id: number) => ipcRenderer.invoke('budgets:getById', id),
+    create: (budgetData: any) => ipcRenderer.invoke('budgets:create', budgetData),
+    update: (id: number, budgetData: any) => ipcRenderer.invoke('budgets:update', id, budgetData),
+    delete: (id: number) => ipcRenderer.invoke('budgets:delete', id)
   }
 }
 

--- a/src/renderer/src/pages/Vendas/Orcamentos/OrcamentosPage.tsx
+++ b/src/renderer/src/pages/Vendas/Orcamentos/OrcamentosPage.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Plus, FileDown, Mail } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { MOCK_BUDGETS } from "../../../data/mockBudgets";
 import { useKpis } from "../../../shared/hooks";
 import type { Budget, Filtros, SortKey } from "../../../shared/types";
 import { filterBudgets, sortBudgets } from "../../../shared/utils";
@@ -19,12 +18,16 @@ export default function OrcamentosPage() {
     const [searchTop] = useState("");
     const [filtros, setFiltros] = useState<Filtros>({ busca: "", status: "", inicio: "", fim: "", cliente: "", projeto: "", min: "" });
     const [sort, setSort] = useState<SortKey>("-emissao");
+    const [budgets, setBudgets] = useState<Budget[]>([]);
 
+    useEffect(() => {
+        window.api.budgets.getAll().then(setBudgets);
+    }, []);
 
     const filtered = useMemo(() => {
-        const f = filterBudgets(MOCK_BUDGETS, { ...filtros, busca: filtros.busca || searchTop });
+        const f = filterBudgets(budgets, { ...filtros, busca: filtros.busca || searchTop });
         return sortBudgets(f, sort);
-    }, [filtros, sort, searchTop]);
+    }, [budgets, filtros, sort, searchTop]);
 
 
     const kpis = useKpis(filtered);
@@ -68,7 +71,7 @@ export default function OrcamentosPage() {
 
 
                 <div className="text-xs opacity-70 mt-6">
-                    *Mock — Integrações futuras: Estoque (disponibilidade), Compras (cotações X), E-mail (envio automático), PDF (modelo de proposta), Revisões & histórico completo.
+                    *Integrações futuras: Estoque (disponibilidade), Compras (cotações X), E-mail (envio automático), PDF (modelo de proposta), Revisões & histórico completo.
                 </div>
             </main>
         </div>


### PR DESCRIPTION
## Summary
- add Prisma Budget and BudgetItem models
- create Budget model, service, and IPC handlers
- expose budget APIs to renderer and integrate budgets page

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run typecheck` *(fails: missing modules)*
- `npm test` *(fails: missing script)*
- `npm run db:migrate -- --name add_budget_tables` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ce88799883238eba755457050667